### PR TITLE
Add ESM database initialization script

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,13 @@
-bb# CMSDB
+# CMSDB
+
+Utilities for managing the Electronic Support Measures (ESM) operator console database.
+
+## Initialization
+
+Run the initialization script to create the SQLite database and platform tables:
+
+```
+python initialize_esm_db.py
+```
+
+This creates `esm_operator.db` with tables for Platform, Aircraft, Facility, GroundUnit, Submarine, Ship, Satellite, and Weapon.

--- a/initialize_esm_db.py
+++ b/initialize_esm_db.py
@@ -1,0 +1,157 @@
+import sqlite3
+
+DB_FILE = "esm_operator.db"
+
+TABLES = {
+    "Platform": """
+        CREATE TABLE IF NOT EXISTS Platform (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            Name TEXT,
+            Category TEXT,
+            PhysicalSize TEXT,
+            Type TEXT,
+            Domain TEXT,
+            Agility TEXT,
+            DamagePoints INTEGER,
+            OODA TEXT,
+            Notes TEXT
+        );
+    """,
+    "Aircraft": """
+        CREATE TABLE IF NOT EXISTS Aircraft (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            Name TEXT,
+            Category TEXT,
+            PhysicalSize TEXT,
+            Type TEXT,
+            Agility TEXT,
+            Length REAL,
+            Span REAL,
+            Height REAL,
+            Crew INTEGER,
+            Armor TEXT,
+            MaxWeight REAL,
+            MaxPayload REAL,
+            DamagePoints INTEGER,
+            OODA TEXT
+        );
+    """,
+    "Facility": """
+        CREATE TABLE IF NOT EXISTS Facility (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            Name TEXT,
+            Category TEXT,
+            PhysicalSize TEXT,
+            Type TEXT,
+            Personnel INTEGER,
+            Armor TEXT,
+            MaxCapacity INTEGER,
+            DamagePoints INTEGER,
+            OODA TEXT
+        );
+    """,
+    "GroundUnit": """
+        CREATE TABLE IF NOT EXISTS GroundUnit (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            Name TEXT,
+            Category TEXT,
+            PhysicalSize TEXT,
+            Type TEXT,
+            Mobility TEXT,
+            Length REAL,
+            Width REAL,
+            Height REAL,
+            Crew INTEGER,
+            Armor TEXT,
+            MaxSpeed REAL,
+            Range REAL,
+            DamagePoints INTEGER,
+            OODA TEXT
+        );
+    """,
+    "Submarine": """
+        CREATE TABLE IF NOT EXISTS Submarine (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            Name TEXT,
+            Category TEXT,
+            PhysicalSize TEXT,
+            Type TEXT,
+            Displacement REAL,
+            Length REAL,
+            Beam REAL,
+            Draft REAL,
+            Crew INTEGER,
+            Armor TEXT,
+            MaxDepth REAL,
+            MaxSpeed REAL,
+            Range REAL,
+            DamagePoints INTEGER,
+            OODA TEXT
+        );
+    """,
+    "Ship": """
+        CREATE TABLE IF NOT EXISTS Ship (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            Name TEXT,
+            Category TEXT,
+            PhysicalSize TEXT,
+            Type TEXT,
+            Displacement REAL,
+            Length REAL,
+            Beam REAL,
+            Draft REAL,
+            Crew INTEGER,
+            Armor TEXT,
+            MaxSpeed REAL,
+            Range REAL,
+            DamagePoints INTEGER,
+            OODA TEXT
+        );
+    """,
+    "Satellite": """
+        CREATE TABLE IF NOT EXISTS Satellite (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            Name TEXT,
+            Category TEXT,
+            PhysicalSize TEXT,
+            Type TEXT,
+            OrbitType TEXT,
+            Altitude REAL,
+            Mass REAL,
+            Power REAL,
+            Mission TEXT,
+            DamagePoints INTEGER,
+            OODA TEXT
+        );
+    """,
+    "Weapon": """
+        CREATE TABLE IF NOT EXISTS Weapon (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            Name TEXT,
+            Category TEXT,
+            PhysicalSize TEXT,
+            Type TEXT,
+            Range REAL,
+            Guidance TEXT,
+            Speed REAL,
+            Warhead TEXT,
+            LaunchPlatform TEXT,
+            DamagePoints INTEGER,
+            OODA TEXT
+        );
+    """
+}
+
+def initialize_database(db_file: str = DB_FILE) -> None:
+    """Create the database and required tables."""
+    conn = sqlite3.connect(db_file)
+    try:
+        cur = conn.cursor()
+        for ddl in TABLES.values():
+            cur.execute(ddl)
+        conn.commit()
+    finally:
+        conn.close()
+
+if __name__ == "__main__":
+    initialize_database()


### PR DESCRIPTION
## Summary
- add `initialize_esm_db.py` script to create SQLite database `esm_operator.db` with platform tables (Platform, Aircraft, Facility, GroundUnit, Submarine, Ship, Satellite, Weapon)
- document initialization procedure in README

## Testing
- `python initialize_esm_db.py`
- `sqlite3 esm_operator.db ".tables"`


------
https://chatgpt.com/codex/tasks/task_e_68ad0db38e588323bee3092401c3dd71