### PR TITLE
Add ESM database initialization and ingestion tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,22 @@
-bb# CMSDB
+# CMSDB
+
+Utilities for managing the Electronic Support Measures (ESM) operator console database.
+
+## Initialization
+
+Run the initialization script to create the SQLite database and platform tables:
+
+```
+python initialize_esm_db.py
+```
+
+This creates `esm_operator.db` with tables for Platform, Aircraft, Facility, GroundUnit, Submarine, Ship, Satellite, and Weapon.
+
+## Ingestion
+
+Use the ingestion CLI to load CSV or JSON data into the database. Sample CSV files are provided in the `templates/` directory.
+
+```
+python ingest.py csv Aircraft templates/Aircraft.csv
+python ingest.py json Ship data/ships.json
+```

--- a/ingest.py
+++ b/ingest.py
@@ -1,0 +1,147 @@
+import argparse
+import csv
+import json
+import sqlite3
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Iterable, Dict, Any, Tuple
+
+DB_FILE = "esm_operator.db"
+SUPPORTED_TABLES = {
+    "Aircraft",
+    "Facility",
+    "GroundUnit",
+    "Submarine",
+    "Ship",
+    "Satellite",
+    "Weapon",
+    "Platform",
+}
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="Ingest data into the ESM database")
+    sub = parser.add_subparsers(dest="command", required=True)
+
+    csv_p = sub.add_parser("csv", help="Load a CSV file")
+    csv_p.add_argument("table", choices=SUPPORTED_TABLES)
+    csv_p.add_argument("path", type=Path)
+
+    json_p = sub.add_parser("json", help="Load a JSON array file")
+    json_p.add_argument("table", choices=SUPPORTED_TABLES)
+    json_p.add_argument("path", type=Path)
+
+    return parser.parse_args()
+
+
+def load_csv(path: Path) -> Iterable[Dict[str, Any]]:
+    with path.open(newline="", encoding="utf-8") as fh:
+        reader = csv.DictReader(fh)
+        for row in reader:
+            yield row
+
+def load_json(path: Path) -> Iterable[Dict[str, Any]]:
+    with path.open(encoding="utf-8") as fh:
+        data = json.load(fh)
+    if not isinstance(data, list):
+        raise ValueError("JSON must be an array of objects")
+    for row in data:
+        if isinstance(row, dict):
+            yield row
+        else:
+            raise ValueError("JSON array must contain objects")
+
+def get_schema(conn: sqlite3.Connection, table: str) -> Tuple[list, Dict[str, str]]:
+    cur = conn.execute(f"PRAGMA table_info({table})")
+    columns = []
+    types: Dict[str, str] = {}
+    for _, name, col_type, *_ in cur.fetchall():
+        columns.append(name)
+        types[name] = col_type.upper()
+    return columns, types
+
+def coerce(value: Any, col_type: str) -> Any:
+    if value is None:
+        return None
+    if isinstance(value, str):
+        value = value.strip()
+    if value == "":
+        return None
+    try:
+        if "INT" in col_type:
+            return int(value)
+        if "REAL" in col_type or "FLOA" in col_type or "DOUB" in col_type:
+            return float(value)
+    except ValueError:
+        raise ValueError("non-numeric data")
+    return value
+
+def ingest_rows(conn: sqlite3.Connection, table: str, rows: Iterable[Dict[str, Any]]) -> Tuple[int, int, int, list]:
+    columns, types = get_schema(conn, table)
+    writable = [c for c in columns if c not in {"id", "created_at", "updated_at"}]
+    if table == "Platform" and "PlatformName" in columns:
+        key_cols = ["PlatformName"]
+    elif "Name" in columns:
+        key_cols = ["Name"]
+    else:
+        key_cols = writable
+
+    inserted = updated = skipped = 0
+    errors = []
+
+    for idx, row in enumerate(rows, start=1):
+        unknown = set(row.keys()) - set(writable)
+        for col in unknown:
+            print(f"Warning: ignoring unknown column '{col}'")
+
+        data: Dict[str, Any] = {}
+        row_errors = []
+        for col in writable:
+            val = row.get(col)
+            try:
+                data[col] = coerce(val, types[col])
+            except ValueError:
+                row_errors.append(f"{col} expects numeric")
+        if any(data.get(k) is None for k in key_cols):
+            row_errors.append("missing required key columns")
+        if row_errors:
+            skipped += 1
+            errors.append((idx, "; ".join(row_errors)))
+            continue
+        cur = conn.cursor()
+        where = " AND ".join([f"{k}=?" for k in key_cols])
+        existing = cur.execute(
+            f"SELECT id, created_at FROM {table} WHERE {where}",
+            [data[k] for k in key_cols],
+        ).fetchone()
+        now = datetime.now(timezone.utc).isoformat()
+        if existing:
+            row_id, created_at = existing
+        else:
+            row_id = None
+            created_at = now
+        cols = ["id"] + writable + ["created_at", "updated_at"]
+        values = [row_id] + [data[c] for c in writable] + [created_at, now]
+        placeholders = ",".join(["?"] * len(cols))
+        cur.execute(
+            f"INSERT OR REPLACE INTO {table} ({','.join(cols)}) VALUES ({placeholders})",
+            values,
+        )
+        if existing:
+            updated += 1
+        else:
+            inserted += 1
+    conn.commit()
+    return inserted, updated, skipped, errors
+
+def main() -> None:
+    args = parse_args()
+    loader = load_csv if args.command == "csv" else load_json
+    rows = loader(args.path)
+    with sqlite3.connect(DB_FILE) as conn:
+        inserted, updated, skipped, errors = ingest_rows(conn, args.table, rows)
+    print(f"Inserted: {inserted}, Updated: {updated}, Skipped: {skipped}")
+    for idx, msg in errors:
+        print(f"Row {idx} skipped: {msg}")
+
+if __name__ == "__main__":
+    main()

--- a/initialize_esm_db.py
+++ b/initialize_esm_db.py
@@ -1,0 +1,173 @@
+import sqlite3
+
+DB_FILE = "esm_operator.db"
+
+TABLES = {
+    "Platform": """
+        CREATE TABLE IF NOT EXISTS Platform (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            Name TEXT,
+            Category TEXT,
+            PhysicalSize TEXT,
+            Type TEXT,
+            Domain TEXT,
+            Agility TEXT,
+            DamagePoints INTEGER,
+            OODA TEXT,
+            Notes TEXT,
+            created_at TEXT DEFAULT CURRENT_TIMESTAMP,
+            updated_at TEXT DEFAULT CURRENT_TIMESTAMP
+        );
+    """,
+    "Aircraft": """
+        CREATE TABLE IF NOT EXISTS Aircraft (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            Name TEXT,
+            Category TEXT,
+            PhysicalSize TEXT,
+            Type TEXT,
+            Agility TEXT,
+            Length REAL,
+            Span REAL,
+            Height REAL,
+            Crew INTEGER,
+            Armor TEXT,
+            MaxWeight REAL,
+            MaxPayload REAL,
+            DamagePoints INTEGER,
+            OODA TEXT,
+            created_at TEXT DEFAULT CURRENT_TIMESTAMP,
+            updated_at TEXT DEFAULT CURRENT_TIMESTAMP
+        );
+    """,
+    "Facility": """
+        CREATE TABLE IF NOT EXISTS Facility (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            Name TEXT,
+            Category TEXT,
+            PhysicalSize TEXT,
+            Type TEXT,
+            Personnel INTEGER,
+            Armor TEXT,
+            MaxCapacity INTEGER,
+            DamagePoints INTEGER,
+            OODA TEXT,
+            created_at TEXT DEFAULT CURRENT_TIMESTAMP,
+            updated_at TEXT DEFAULT CURRENT_TIMESTAMP
+        );
+    """,
+    "GroundUnit": """
+        CREATE TABLE IF NOT EXISTS GroundUnit (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            Name TEXT,
+            Category TEXT,
+            PhysicalSize TEXT,
+            Type TEXT,
+            Mobility TEXT,
+            Length REAL,
+            Width REAL,
+            Height REAL,
+            Crew INTEGER,
+            Armor TEXT,
+            MaxSpeed REAL,
+            Range REAL,
+            DamagePoints INTEGER,
+            OODA TEXT,
+            created_at TEXT DEFAULT CURRENT_TIMESTAMP,
+            updated_at TEXT DEFAULT CURRENT_TIMESTAMP
+        );
+    """,
+    "Submarine": """
+        CREATE TABLE IF NOT EXISTS Submarine (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            Name TEXT,
+            Category TEXT,
+            PhysicalSize TEXT,
+            Type TEXT,
+            Displacement REAL,
+            Length REAL,
+            Beam REAL,
+            Draft REAL,
+            Crew INTEGER,
+            Armor TEXT,
+            MaxDepth REAL,
+            MaxSpeed REAL,
+            Range REAL,
+            DamagePoints INTEGER,
+            OODA TEXT,
+            created_at TEXT DEFAULT CURRENT_TIMESTAMP,
+            updated_at TEXT DEFAULT CURRENT_TIMESTAMP
+        );
+    """,
+    "Ship": """
+        CREATE TABLE IF NOT EXISTS Ship (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            Name TEXT,
+            Category TEXT,
+            PhysicalSize TEXT,
+            Type TEXT,
+            Displacement REAL,
+            Length REAL,
+            Beam REAL,
+            Draft REAL,
+            Crew INTEGER,
+            Armor TEXT,
+            MaxSpeed REAL,
+            Range REAL,
+            DamagePoints INTEGER,
+            OODA TEXT,
+            created_at TEXT DEFAULT CURRENT_TIMESTAMP,
+            updated_at TEXT DEFAULT CURRENT_TIMESTAMP
+        );
+    """,
+    "Satellite": """
+        CREATE TABLE IF NOT EXISTS Satellite (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            Name TEXT,
+            Category TEXT,
+            PhysicalSize TEXT,
+            Type TEXT,
+            OrbitType TEXT,
+            Altitude REAL,
+            Mass REAL,
+            Power REAL,
+            Mission TEXT,
+            DamagePoints INTEGER,
+            OODA TEXT,
+            created_at TEXT DEFAULT CURRENT_TIMESTAMP,
+            updated_at TEXT DEFAULT CURRENT_TIMESTAMP
+        );
+    """,
+    "Weapon": """
+        CREATE TABLE IF NOT EXISTS Weapon (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            Name TEXT,
+            Category TEXT,
+            PhysicalSize TEXT,
+            Type TEXT,
+            Range REAL,
+            Guidance TEXT,
+            Speed REAL,
+            Warhead TEXT,
+            LaunchPlatform TEXT,
+            DamagePoints INTEGER,
+            OODA TEXT,
+            created_at TEXT DEFAULT CURRENT_TIMESTAMP,
+            updated_at TEXT DEFAULT CURRENT_TIMESTAMP
+        );
+    """
+}
+
+def initialize_database(db_file: str = DB_FILE) -> None:
+    """Create the database and required tables."""
+    conn = sqlite3.connect(db_file)
+    try:
+        cur = conn.cursor()
+        for ddl in TABLES.values():
+            cur.execute(ddl)
+        conn.commit()
+    finally:
+        conn.close()
+
+if __name__ == "__main__":
+    initialize_database()

--- a/templates/Aircraft.csv
+++ b/templates/Aircraft.csv
@@ -1,0 +1,3 @@
+Name,Category,PhysicalSize,Type,Agility,Length,Span,Height,Crew,Armor,MaxWeight,MaxPayload,DamagePoints,OODA
+F-16,Fixed-wing,Small,Fighter,High,15,9.5,4.8,1,Light,12000,7000,10,Fast
+F-18,Fixed-wing,Medium,Attack,Medium,17,11,5,2,Light,14000,8000,12,Moderate

--- a/templates/Facility.csv
+++ b/templates/Facility.csv
@@ -1,0 +1,3 @@
+Name,Category,PhysicalSize,Type,Personnel,Armor,MaxCapacity,DamagePoints,OODA
+BaseA,Military,Large,Airbase,1000,Concrete,50,40,Moderate
+BaseB,Civil,Medium,Harbor,500,Steel,30,30,Slow

--- a/templates/GroundUnit.csv
+++ b/templates/GroundUnit.csv
@@ -1,0 +1,3 @@
+Name,Category,PhysicalSize,Type,Mobility,Length,Width,Height,Crew,Armor,MaxSpeed,Range,DamagePoints,OODA
+TankA,Armor,Medium,MBT,Tracked,6.5,3.5,2.4,4,Heavy,60,500,15,Moderate
+JeepB,Recon,Small,Jeep,Wheeled,3.8,1.7,1.8,2,Light,120,400,5,Fast

--- a/templates/Platform.csv
+++ b/templates/Platform.csv
@@ -1,0 +1,3 @@
+Name,Category,PhysicalSize,Type,Domain,Agility,DamagePoints,OODA,Notes
+Alpha,Air,Small,Fighter,Air,High,10,Fast,Test platform
+Bravo,Sea,Medium,Ship,Sea,Low,20,Slow,Second platform

--- a/templates/Satellite.csv
+++ b/templates/Satellite.csv
@@ -1,0 +1,3 @@
+Name,Category,PhysicalSize,Type,OrbitType,Altitude,Mass,Power,Mission,DamagePoints,OODA
+SatA,Communication,Small,Comms,GEO,35786,2000,1.5,Relay,5,Fast
+SatB,Reconnaissance,Medium,Imaging,LEO,500,500,2,Imaging,8,Fast

--- a/templates/Ship.csv
+++ b/templates/Ship.csv
@@ -1,0 +1,3 @@
+Name,Category,PhysicalSize,Type,Displacement,Length,Beam,Draft,Crew,Armor,MaxSpeed,Range,DamagePoints,OODA
+DestroyerA,Combat,Large,Destroyer,8000,150,20,6,300,Steel,30,6000,35,Moderate
+FrigateB,Combat,Medium,Frigate,4000,130,15,5,200,Steel,28,5000,25,Moderate

--- a/templates/Submarine.csv
+++ b/templates/Submarine.csv
@@ -1,0 +1,3 @@
+Name,Category,PhysicalSize,Type,Displacement,Length,Beam,Draft,Crew,Armor,MaxDepth,MaxSpeed,Range,DamagePoints,OODA
+SubA,Attack,Medium,SSN,7000,110,10,9,100,Steel,300,30,8000,25,Slow
+SubB,Ballistic,Large,SSBN,15000,150,12,11,130,Steel,400,25,10000,40,Slow

--- a/templates/Weapon.csv
+++ b/templates/Weapon.csv
@@ -1,0 +1,3 @@
+Name,Category,PhysicalSize,Type,Range,Guidance,Speed,Warhead,LaunchPlatform,DamagePoints,OODA
+MissileA,Missile,Medium,SurfaceToAir,150,Infrared,3,Explosive,Ground,20,Fast
+TorpedoB,Torpedo,Small,AntiShip,50,Acoustic,60,Explosive,Submarine,15,Moderate


### PR DESCRIPTION
## Summary
- add timestamps to platform tables when initializing the SQLite database
- implement `ingest.py` CLI with CSV/JSON subcommands for upserting data with type coercion and timestamp preservation
- provide sample CSV templates and README instructions for ingesting data

## Testing
- `python initialize_esm_db.py`
- `python ingest.py csv Aircraft templates/Aircraft.csv`
- `sqlite3 esm_operator.db "SELECT Name, Category, created_at, updated_at FROM Aircraft;"`


------
https://chatgpt.com/codex/tasks/task_e_68ad0db38e588323bee3092401c3dd71